### PR TITLE
feat: create and use mega file

### DIFF
--- a/src/helpers/FileLineBreakdown.ts
+++ b/src/helpers/FileLineBreakdown.ts
@@ -1,7 +1,9 @@
 // src/helpers/createfileLineBreakdown.ts
 import { promises as fs } from 'fs'; // Use promises API
 
-export async function createfileLineBreakdown(filePaths: string[]): Promise<string> {
+export async function createfileLineBreakdown(
+  filePaths: string[],
+): Promise<string> {
   console.log('Creating fileLineBreakdown file...');
   const fileLineBreakdown: { [key: string]: string[] } = {}; // Initialize as an object
 
@@ -9,15 +11,20 @@ export async function createfileLineBreakdown(filePaths: string[]): Promise<stri
     for (const filePath of filePaths) {
       const content: string = await fs.readFile(filePath, 'utf8'); // Read file as string
       const code = content.split('\n');
-      fileLineBreakdown[filePath] = code.map((line, index) => `${index + 1}: ${line}`);
-
+      fileLineBreakdown[filePath] = code.map(
+        (line, index) => `${index + 1}: ${line}`,
+      );
     }
 
     // Write the mega file to the src directory
     const outputPath = 'src/fileLineBreakdown.json';
-    await fs.writeFile(outputPath, JSON.stringify(fileLineBreakdown, null, 2), 'utf8');
+    await fs.writeFile(
+      outputPath,
+      JSON.stringify(fileLineBreakdown, null, 2),
+      'utf8',
+    );
 
-    return outputPath
+    return outputPath;
   } catch (error) {
     throw error;
   }

--- a/src/helpers/FileLineBreakdown.ts
+++ b/src/helpers/FileLineBreakdown.ts
@@ -1,0 +1,24 @@
+// src/helpers/createfileLineBreakdown.ts
+import { promises as fs } from 'fs'; // Use promises API
+
+export async function createfileLineBreakdown(filePaths: string[]): Promise<string> {
+  console.log('Creating fileLineBreakdown file...');
+  const fileLineBreakdown: { [key: string]: string[] } = {}; // Initialize as an object
+
+  try {
+    for (const filePath of filePaths) {
+      const content: string = await fs.readFile(filePath, 'utf8'); // Read file as string
+      const code = content.split('\n');
+      fileLineBreakdown[filePath] = code.map((line, index) => `${index + 1}: ${line}`);
+
+    }
+
+    // Write the mega file to the src directory
+    const outputPath = 'src/fileLineBreakdown.json';
+    await fs.writeFile(outputPath, JSON.stringify(fileLineBreakdown, null, 2), 'utf8');
+
+    return outputPath
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,6 +1,7 @@
 import { runCodeScan } from '@/helpers/CodeBaseScan';
 import { CreateAssistant } from '@/helpers/ModelHandler';
 import { initConfig, saveAPIKey } from '@/helpers/config';
+import { createfileLineBreakdown } from '@/helpers/FileLineBreakdown';
 
 // Start Generation Here
 async function init(apiKey: string, framework: string) {
@@ -8,7 +9,9 @@ async function init(apiKey: string, framework: string) {
     saveAPIKey(apiKey);
     const contextFiles = await runCodeScan();
 
-    const response = await CreateAssistant(apiKey, contextFiles);
+    const fileLineBreakdown = await createfileLineBreakdown(contextFiles);
+
+    const response = await CreateAssistant(apiKey, fileLineBreakdown);
 
     const _config = {
       framework: framework,


### PR DESCRIPTION
In this PR, I change the way we pass files to the OpenAI assistant. Previously, we passed an array of file paths. However, we had an issue of the response hallucinating the line numbers in the response. We discovered that this was due to the vector store that OpenAI uses truncates the data and isn't aware of line numbers of the original code.

So now, instead of passing all the files and handling different file types, i create a json file. the object has keys of the file paths and the values is an array of line numbers and line content. this has drastically improved the hallucination issues. More testing needs to be done to ensure the hallucination issue is totally eliminated. But from light testing it's much better.