### PR TITLE
feat: working read api key if existing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ program
         });
 
         if (!useExistingKeyResponse.useExistingKey) {
-          apiKey = '';
+          apiKey = ''; // clear api key so it triggers the next input prompt
         }
       }
 


### PR DESCRIPTION
In this PR, I make it so the init function uses the open_ai key in the .env file if it exists. If it doesn't exist you can pass it in as normal. I thought that it's important the user confirms they want to use their personal API key. This is because they might not realise it uses their API key if it does (e.g. they might use it elsewhere in codebase and not expect our package to use it). So I added a confirmation Y/n.

![image](https://github.com/user-attachments/assets/e562969f-d470-4862-876a-f34b6c2e4ad9)

![image](https://github.com/user-attachments/assets/22c02b5b-fde6-4e2d-8051-ce2d882c363c)
