### PR TITLE
feat: remove --report

### DIFF
--- a/readme
+++ b/readme
@@ -38,8 +38,6 @@ guidedog check [options]
 
 Check the accessibility of your project, receive an rating and suggestions.
 
-- `--report`: Generate a detailed accessibility report.
-
 ```bash
 guidedog fix
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,15 +73,12 @@ program
 program
   .command('check')
   .description('Check accessibility of your project')
-  .option('-r, --report', 'Generate a detailed accessibility report')
   .option('-s, --score', 'Assess accessibility score')
   .action(async (options) => {
     try {
       console.log('Starting check...');
 
-      if (options.report) {
-        await check('report');
-      } else if (options.score) {
+      if (options.score) {
         await check('score');
       } else {
         await check();

--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -25,7 +25,7 @@ export async function check(flag?: string) {
     }
 
     // analyse to get axe-core score and violations
-    const results = await analyse(_config.framework);
+    // const results = await analyse(_config.framework);
 
     const filePaths = await runCodeScan();
 
@@ -39,21 +39,19 @@ export async function check(flag?: string) {
 
     const suggestions = await getRepoSuggestions(promptFiles);
 
-    if (flag === 'score') {
-      return results.score;
-    }
+    // if (flag === 'score') {
+    //   return results.score;
+    // }
 
-    if (flag === 'report') {
-      // Write suggestions to guidedog folder
-      fs.writeFileSync(
-        `${DIR_PATH}/suggestions.json`,
-        JSON.stringify(suggestions, null, 2),
-        {
-          encoding: 'utf8',
-          flag: 'w',
-        },
-      );
-    }
+    // Write suggestions to guidedog folder
+    fs.writeFileSync(
+      `${DIR_PATH}/suggestions.json`,
+      JSON.stringify(suggestions, null, 2),
+      {
+        encoding: 'utf8',
+        flag: 'w',
+      },
+    );
 
     // Write suggestions to latest run for historical purposes
     fs.writeFileSync(


### PR DESCRIPTION
I removed the report flag. Previously it was used to write the suggestions to file. But now we want that always to happen. So it was made the default. Works as expected.